### PR TITLE
safely deal with corrupt files in a folder

### DIFF
--- a/scripts/fileStreams.py
+++ b/scripts/fileStreams.py
@@ -33,8 +33,7 @@ def getZstFileJsonStream(path: str, chunk_size=1024*1024*10) -> Iterator[tuple[i
 				chunk = reader.read(chunk_size)
 			except zstandard.ZstdError:
 				print("Error reading file: " + path)
-				print(traceback.format_exc())
-				break
+				raise
 			if not chunk:
 				break
 			currentString += chunk.decode("utf-8", "replace")
@@ -75,7 +74,10 @@ def getFileJsonStream(path: str) -> Iterator[tuple[int, dict]]|None:
 	if path.endswith(".json"):
 		return getJsonFileJsonStream(path)
 	elif path.endswith(".zst"):
-		return getZstFileJsonStream(path)
+		try:
+			return getZstFileJsonStream(path)
+		except zstandard.ZstdError:
+			return None
 	elif path.endswith(".zst_blocks"):
 		return getZstBlocksFileJsonStream(path)
 	else:

--- a/scripts/fileStreams.py
+++ b/scripts/fileStreams.py
@@ -33,7 +33,8 @@ def getZstFileJsonStream(path: str, chunk_size=1024*1024*10) -> Iterator[tuple[i
 				chunk = reader.read(chunk_size)
 			except zstandard.ZstdError:
 				print("Error reading file: " + path)
-				raise
+				print(traceback.format_exc())
+				break
 			if not chunk:
 				break
 			currentString += chunk.decode("utf-8", "replace")
@@ -74,10 +75,7 @@ def getFileJsonStream(path: str) -> Iterator[tuple[int, dict]]|None:
 	if path.endswith(".json"):
 		return getJsonFileJsonStream(path)
 	elif path.endswith(".zst"):
-		try:
-			return getZstFileJsonStream(path)
-		except zstandard.ZstdError:
-			return None
+		return getZstFileJsonStream(path)
 	elif path.endswith(".zst_blocks"):
 		return getZstBlocksFileJsonStream(path)
 	else:

--- a/scripts/processFiles.py
+++ b/scripts/processFiles.py
@@ -20,7 +20,7 @@ def processFile(path: str):
 	if jsonStream is None:
 		print(f"Skipping unknown file {path}")
 		return
-        i = 0 # in case jsonStream is corrupt
+	i = 0 # in case jsonStream is corrupt
 	for i, (lineLength, row) in enumerate(jsonStream):
 		if i % 10_000 == 0:
 			print(f"\rRow {i}", end="")

--- a/scripts/processFiles.py
+++ b/scripts/processFiles.py
@@ -20,6 +20,7 @@ def processFile(path: str):
 	if jsonStream is None:
 		print(f"Skipping unknown file {path}")
 		return
+        i = 0 # in case jsonStream is corrupt
 	for i, (lineLength, row) in enumerate(jsonStream):
 		if i % 10_000 == 0:
 			print(f"\rRow {i}", end="")


### PR DESCRIPTION
Currently if there is a corrupt file in a dir the whole processing crashes with:

```
Processing file   4 ./economicCollapse_comments.zst
Error reading file: ./economicCollapse_comments.zst
Traceback (most recent call last):
  File "arctic_shift/scripts/fileStreams.py", line 33, in getZstFileJsonStream
    chunk = reader.read(chunk_size)
zstd.ZstdError: zstd decompress error: Unknown frame descriptor

Traceback (most recent call last):
  File "arctic_shift/scripts/processFiles.py", line 64, in <module>
    main()
  File "arctic_shift/scripts/processFiles.py", line 57, in main
    processFolder(fileOrFolderPath)
  File "arctic_shift/scripts/processFiles.py", line 53, in processFolder
    processFile(file)
  File "arctic_shift/scripts/processFiles.py", line 37, in processFile
    print(f"\rRow {i+1}")
UnboundLocalError: local variable 'i' referenced before assignment
```
it fails in:
```
print(f"\rRow {i+1}")
```
because the generator was empty to start with.

I tried to solve it cleanly on the generator side, but it's far from trivial the way it has been designed, so it looks like setting the default `i=0` solves it in the most simple way - not the cleanest solution but it works.

There are probably other ways to fix it, so this is just a suggestion.
